### PR TITLE
some work

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -99,7 +99,7 @@ In other cases the `store_type` and `store_init` arguments can be used.
 The `store_type`:
 
 1. Is generic on `<K, R>` where `K` is the key type and `R` is the memoized function's return type.
-2. `K` and `R` have no bounds.
+2. `K` and `R` must have no bounds.
 3. Provides the following functions where `K` and `R` may have bounds:
     - `fn insert(&mut self, key: K, value: R)` // return type ignored
     - `fn get(&self, key: &K) -> Option<&R>`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,10 +114,10 @@ fn expand_fn_block(original_fn_block: Block, return_type: Type, attr_args: AttrA
             // 2. Was certainly initialized in the same `Once::call_once`.
             CACHE.assume_init_ref()
         };
+        let #key = #key_expr;
         let mut type_map_mutex_guard = type_map_mutex
             .lock()
             .expect("handling of poisoning is not supported");
-        let #key = #key_expr;
         let cache = {
             // This function and the similar function, `obtain_mutable_cache` exist for the sole
             // purpose of allowing `key_type` to be optional. To do that, the key type must be

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,9 +77,7 @@ fn expand_fn_block(original_fn_block: Block, return_type: Type, attr_args: AttrA
             // The following `Sync` bound applies to the store type and by extension also to the
             // key type and the return type.
             // It seems that in the current implementation this `Sync` bound is entirely
-            // redundant because:
-            // 1. The key type and return type are `'static`.
-            // 2. All operations on the cache store are within a `MutexGuard`.
+            // redundant because all operations on the cache store are within a `MutexGuard`.
             // Nonetheless, if Rust ever supports generic statics, this type map workaround could
             // be removed and the use of `Mutex` replaced with the use of a `RwLock`.
             // In that case, multiple references of the key type and the return type could be read

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -18,12 +18,12 @@ fn generic_in_impl() {
 
     impl<T> GenericStruct<T>
     where
-        T: Clone + Send + Eq + PartialEq + Hash + 'static + Sync,
+        T: 'static + Clone + Sync + Eq + Hash,
     {
         #[memoized(key_expr = (self.a.clone(), b.clone()))]
         fn f<U>(&self, b: U) -> (T, U)
         where
-            U: Clone + Send + Eq + PartialEq + Hash + 'static + Sync,
+            U: 'static + Clone + Sync + Eq + Hash,
         {
             (self.a.clone(), b)
         }


### PR DESCRIPTION
- that K and R "must have no bounds"
- sync redundant not because key and return are static
- correct bounds in generic test
- move `let key` to before mutex lock
