### PR TITLE
remove redundant parsing of `ItemFn`

### DIFF
--- a/tests/compile_fail/not_on_a_function.stderr
+++ b/tests/compile_fail/not_on_a_function.stderr
@@ -1,4 +1,4 @@
-error: must be used on a function
+error: expected `fn`
  --> tests/compile_fail/not_on_a_function.rs:4:1
   |
 4 | struct A;


### PR DESCRIPTION
Co-authored-by: Shahar Dawn Or <mightyiampresence@gmail.com>
