### PR TITLE
install cargo-make in github action via binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,6 @@ jobs:
       - uses: Swatinem/rust-cache@v1
         with:
           cache-on-failure: true
-      - run: cargo install cargo-make
+      - uses: davidB/rust-cargo-make@v1
       - run: cargo make ci
 


### PR DESCRIPTION
closes #157 (workaround)
