### PR TITLE
some work

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,6 +202,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "cargo_toml"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5809dd3e6444651fd1cdd3dbec71eca438c439a0fcc8081674a14da0afe50185"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "toml",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -967,10 +978,12 @@ name = "michie"
 version = "0.2.1"
 dependencies = [
  "cargo-make",
+ "cargo_toml",
  "conventional_commits_linter",
  "itertools",
  "michie-macro",
  "regex 1.5.5",
+ "semver",
  "trybuild",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,9 +32,11 @@ michie-macro = { path = "macro", version = "0.2.0" }
 
 [dev-dependencies]
 cargo-make = "0.35.12"
+cargo_toml = "0.11.5"
 conventional_commits_linter = "0.12.1"
 itertools = "0.10.3"
 regex = "1.5.5"
-trybuild = "^1.0.56"
+semver = "1.0.9"
+trybuild = "1.0.56"
 
 [features]

--- a/README.md
+++ b/README.md
@@ -151,7 +151,10 @@ The original function expands into something similar to this:
 fn f(input: Input) -> Output {
     static STORE = Mutex::new(#store_init);
     let key = #key_expr;
-    if let Some(hit) = STORE.lock().unwrap().get(&key) {
+    let store_mutex_guard = STORE.lock().unwrap();
+    let attempt = store_mutex_guard.get(&key).cloned();
+    drop(store_mutex_guard);
+    if let Some(hit) = attempt {
         return hit;
     } else {
         let miss = #original_fn_body;

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -123,7 +123,7 @@ fn expand_fn_block(original_fn_block: Block, return_type: Type, attr_args: AttrA
             .entry(type_id)
             .or_insert_with(|| {
                 let store: #store_type = #store_init;
-                fn inference_hint<K, R, S: ::michie::MemoizationStore<K, R>>(k: &K, s: &S) {}
+                fn inference_hint<K, R, S: ::michie::MemoizationStore<K, R>>(_k: &K, _s: &S) {}
                 inference_hint::<#key_type, #return_type, #store_type>(#key_ref, &store);
                 ::std::boxed::Box::new(store)
             });

--- a/tests/dependencies.rs
+++ b/tests/dependencies.rs
@@ -1,0 +1,21 @@
+use cargo_toml::{Dependency, Manifest};
+use semver::VersionReq;
+
+#[test]
+fn all_dev_deps_are_caret_constrained() {
+    let manifest = Manifest::from_path("Cargo.toml").unwrap();
+    let all_are_caret = manifest
+        .dev_dependencies
+        .into_iter()
+        .map(|(_, dep)| {
+            let version = match dep {
+                Dependency::Simple(version) => version,
+                Dependency::Detailed(detailed) => detailed.version.unwrap(),
+            };
+            let comparators = VersionReq::parse(&version).unwrap().comparators;
+            assert_eq!(comparators.len(), 1);
+            comparators[0].op
+        })
+        .all(|op| op == semver::Op::Caret);
+    assert!(all_are_caret);
+}


### PR DESCRIPTION
- test: all dev_deps are single constraint caret
- style: expansion unused args prefixed with underscores
- docs: explicit guard drop in "how it works"
