### PR TITLE
implement support for `cached`-style result and option attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ michie (sounds like Mickey) — an attribute macro that adds [memoization] to a 
 1. [key_type](#key_type)
 1. [store_type](#store_type)
 1. [store_init](#store_init)
-1. [result and option](#result-and-option)
+1. [dont cache errors](#dont-cache-errors)
 1. [Store inference and the default store](#store-inference-and-the-default-store)
 1. [Type requirements](#type-requirements)
     1. [General bounds](#general-bounds)
@@ -111,14 +111,14 @@ fn f(input: usize) -> usize {
 }
 ```
 
-# result and option
+# dont cache errors
 
-Michie can be instructed to only store the success cases of `Result<T,E>` and `Option<T>`
+Michie can be instructed to only store the success cases of `Result<T,E>`
 computations.
 
 ``` rust
 use michie::{memoized};
-#[memoized(key_expr = input, result = true)]
+#[memoized(key_expr = input, dont_cache_errors)]
 fn f(input: i32) -> Result<u16,&'static str> {
     if input >= 0 {
         Ok(input as u16)

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ michie (sounds like Mickey) — an attribute macro that adds [memoization] to a 
 1. [key_type](#key_type)
 1. [store_type](#store_type)
 1. [store_init](#store_init)
+1. [result and option](#result-and-option)
 1. [Store inference and the default store](#store-inference-and-the-default-store)
 1. [Type requirements](#type-requirements)
     1. [General bounds](#general-bounds)
@@ -107,6 +108,23 @@ use std::collections::HashMap;
 fn f(input: usize) -> usize {
     // expensive calculation
     # unimplemented!()
+}
+```
+
+# result and option
+
+Michie can be instructed to only store the success cases of `Result<T,E>` and `Option<T>`
+computations.
+
+``` rust
+use michie::{memoized};
+#[memoized(key_expr = input, result = true)]
+fn f(input: i32) -> Result<u16,&'static str> {
+    if input >= 0 {
+        Ok(input as u16)
+    } else {
+        Err("input is negative!")
+    }
 }
 ```
 

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -116,7 +116,7 @@ fn expand_fn_block(original_fn_block: Block, return_type: Type, attr_args: AttrA
             quote_spanned! { Span::mixed_site() => ::core::result::Result::Ok(hit) },
             quote_spanned! {
                 Span::mixed_site() =>
-                    if let ::core::result::Result::Ok(data) = miss {
+                    if let ::core::result::Result::Ok(ref data) = miss {
                         ::michie::MemoizationStore::insert(store, #key, ::core::clone::Clone::clone(&data));
                     }
             },
@@ -125,7 +125,7 @@ fn expand_fn_block(original_fn_block: Block, return_type: Type, attr_args: AttrA
             quote_spanned! { Span::mixed_site() => ::core::option::Option::Some(hit) },
             quote_spanned! {
                 Span::mixed_site() =>
-                    if let ::core::option::Option::Some(data) = miss {
+                    if let ::core::option::Option::Some(ref data) = miss {
                         ::michie::MemoizationStore::insert(store, #key, ::core::clone::Clone::clone(&data));
                     }
             },

--- a/tests/compile_fail/on_a_function_with_a_complex_return_type_and_dont_cache_errors.rs
+++ b/tests/compile_fail/on_a_function_with_a_complex_return_type_and_dont_cache_errors.rs
@@ -1,0 +1,6 @@
+use michie::memoized;
+
+#[memoized(key_expr = (), dont_cache_errors)]
+fn f<T>() -> (Result<i32,u32>) { Ok(4) }
+
+fn main() {}

--- a/tests/compile_fail/on_a_function_with_a_complex_return_type_and_dont_cache_errors.stderr
+++ b/tests/compile_fail/on_a_function_with_a_complex_return_type_and_dont_cache_errors.stderr
@@ -1,0 +1,7 @@
+error: function return type too complex; please return Result<T,E> for some T, E
+ --> tests/compile_fail/on_a_function_with_a_complex_return_type_and_dont_cache_errors.rs:3:1
+  |
+3 | #[memoized(key_expr = (), dont_cache_errors)]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in the attribute macro `memoized` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/compile_fail/on_a_function_without_result_type_but_with_dont_cache_errors.rs
+++ b/tests/compile_fail/on_a_function_without_result_type_but_with_dont_cache_errors.rs
@@ -1,0 +1,6 @@
+use michie::memoized;
+
+#[memoized(key_expr = (), dont_cache_errors)]
+fn f() -> i32 { 4 }
+
+fn main() {}

--- a/tests/compile_fail/on_a_function_without_result_type_but_with_dont_cache_errors.stderr
+++ b/tests/compile_fail/on_a_function_without_result_type_but_with_dont_cache_errors.stderr
@@ -1,0 +1,7 @@
+error: function return type must be Result<T,E> (for some T, E)
+ --> tests/compile_fail/on_a_function_without_result_type_but_with_dont_cache_errors.rs:3:1
+  |
+3 | #[memoized(key_expr = (), dont_cache_errors)]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in the attribute macro `memoized` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -261,6 +261,21 @@ fn still_memoizes_ok_values() {
 }
 
 #[test]
+fn memoizes_ok_values_without_copy() {
+    let mut count = 0;
+
+    #[memoized(key_expr = (), result = true)]
+    fn f(count: &mut i32) -> Result<Vec<()>, ()> {
+        *count += 1;
+        Ok(Vec::default())
+    }
+
+    assert!(f(&mut count).is_ok());
+    assert!(f(&mut count).is_ok());
+    assert_eq!(count, 1);
+}
+
+#[test]
 fn can_avoid_memoizing_none_values() {
     let mut count = 0;
 
@@ -283,6 +298,21 @@ fn still_memoizes_some_values() {
     fn f(count: &mut i32) -> Option<()> {
         *count += 1;
         Some(())
+    }
+
+    assert!(f(&mut count).is_some());
+    assert!(f(&mut count).is_some());
+    assert_eq!(count, 1);
+}
+
+#[test]
+fn memoizes_some_values_without_copy() {
+    let mut count = 0;
+
+    #[memoized(key_expr = (), option = true)]
+    fn f(count: &mut i32) -> Option<Vec<()>> {
+        *count += 1;
+        Some(Vec::default())
     }
 
     assert!(f(&mut count).is_some());

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -234,7 +234,7 @@ fn store_type_is_inferred_not_from_store_init_alone() {
 fn can_avoid_memoizing_error_values() {
     let mut count = 0;
 
-    #[memoized(key_expr = (), result = true)]
+    #[memoized(key_expr = (), dont_cache_errors)]
     fn f(count: &mut i32) -> Result<(), ()> {
         *count += 1;
         Err(())
@@ -249,7 +249,7 @@ fn can_avoid_memoizing_error_values() {
 fn still_memoizes_ok_values() {
     let mut count = 0;
 
-    #[memoized(key_expr = (), result = true)]
+    #[memoized(key_expr = (), dont_cache_errors)]
     fn f(count: &mut i32) -> Result<(), ()> {
         *count += 1;
         Ok(())
@@ -264,7 +264,7 @@ fn still_memoizes_ok_values() {
 fn memoizes_ok_values_without_copy() {
     let mut count = 0;
 
-    #[memoized(key_expr = (), result = true)]
+    #[memoized(key_expr = (), dont_cache_errors)]
     fn f(count: &mut i32) -> Result<Vec<()>, ()> {
         *count += 1;
         Ok(Vec::default())
@@ -272,50 +272,5 @@ fn memoizes_ok_values_without_copy() {
 
     assert!(f(&mut count).is_ok());
     assert!(f(&mut count).is_ok());
-    assert_eq!(count, 1);
-}
-
-#[test]
-fn can_avoid_memoizing_none_values() {
-    let mut count = 0;
-
-    #[memoized(key_expr = (), option = true)]
-    fn f(count: &mut i32) -> Option<()> {
-        *count += 1;
-        None
-    }
-
-    assert!(f(&mut count).is_none());
-    assert!(f(&mut count).is_none());
-    assert_eq!(count, 2);
-}
-
-#[test]
-fn still_memoizes_some_values() {
-    let mut count = 0;
-
-    #[memoized(key_expr = (), option = true)]
-    fn f(count: &mut i32) -> Option<()> {
-        *count += 1;
-        Some(())
-    }
-
-    assert!(f(&mut count).is_some());
-    assert!(f(&mut count).is_some());
-    assert_eq!(count, 1);
-}
-
-#[test]
-fn memoizes_some_values_without_copy() {
-    let mut count = 0;
-
-    #[memoized(key_expr = (), option = true)]
-    fn f(count: &mut i32) -> Option<Vec<()>> {
-        *count += 1;
-        Some(Vec::default())
-    }
-
-    assert!(f(&mut count).is_some());
-    assert!(f(&mut count).is_some());
     assert_eq!(count, 1);
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -229,3 +229,63 @@ fn store_type_is_inferred_not_from_store_init_alone() {
         input
     }
 }
+
+#[test]
+fn can_avoid_memoizing_error_values() {
+    let mut count = 0;
+
+    #[memoized(key_expr = (), result = true)]
+    fn f(count: &mut i32) -> Result<(), ()> {
+        *count += 1;
+        Err(())
+    }
+
+    assert!(f(&mut count).is_err());
+    assert!(f(&mut count).is_err());
+    assert_eq!(count, 2);
+}
+
+#[test]
+fn still_memoizes_ok_values() {
+    let mut count = 0;
+
+    #[memoized(key_expr = (), result = true)]
+    fn f(count: &mut i32) -> Result<(), ()> {
+        *count += 1;
+        Ok(())
+    }
+
+    assert!(f(&mut count).is_ok());
+    assert!(f(&mut count).is_ok());
+    assert_eq!(count, 1);
+}
+
+#[test]
+fn can_avoid_memoizing_none_values() {
+    let mut count = 0;
+
+    #[memoized(key_expr = (), option = true)]
+    fn f(count: &mut i32) -> Option<()> {
+        *count += 1;
+        None
+    }
+
+    assert!(f(&mut count).is_none());
+    assert!(f(&mut count).is_none());
+    assert_eq!(count, 2);
+}
+
+#[test]
+fn still_memoizes_some_values() {
+    let mut count = 0;
+
+    #[memoized(key_expr = (), option = true)]
+    fn f(count: &mut i32) -> Option<()> {
+        *count += 1;
+        Some(())
+    }
+
+    assert!(f(&mut count).is_some());
+    assert!(f(&mut count).is_some());
+    assert_eq!(count, 1);
+}


### PR DESCRIPTION
This PR implements support for `result` and `option` attributes, where the cache is instructed to only cache the success case of a function returning `Result<T,E>` or `Option<T>`. This mimics the interface of [cached](https://docs.rs/cached), but if you would prefer a different interface, that's fine by me.