### PR TITLE
feat: remove key_type parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ michie (sounds like Mickey) — an attribute macro that adds [memoization] to a 
 1. [Features](#features)
 1. [Non-features](#non-features)
 1. [key_expr](#key_expr)
-1. [key_type](#key_type)
 1. [store_type](#store_type)
 1. [store_init](#store_init)
 1. [Store inference and the default store](#store-inference-and-the-default-store)
@@ -60,19 +59,6 @@ In the following example the `key_expr` is simply the name of the only parameter
 use michie::memoized;
 #[memoized(key_expr = input)]
 fn f(input: usize) -> usize {
-    // expensive calculation
-    # unimplemented!()
-}
-```
-
-# key_type
-
-While the type of the key supports inference, it may also be specified using the `key_type` argument:
-
-```rust
-use michie::memoized;
-#[memoized(key_type = u64, key_expr = input.into())]
-fn f(input: u32) -> u32 {
     // expensive calculation
     # unimplemented!()
 }

--- a/tests/compile_fail/key_type_mismatch.rs
+++ b/tests/compile_fail/key_type_mismatch.rs
@@ -1,6 +1,7 @@
 use michie::memoized;
+use std::collections::HashMap;
 
-#[memoized(key_type = (), key_expr = a)]
+#[memoized(key_expr = a, store_type = HashMap<usize, bool>)]
 fn f(a: bool) -> bool {
     a
 }

--- a/tests/compile_fail/key_type_mismatch.stderr
+++ b/tests/compile_fail/key_type_mismatch.stderr
@@ -1,7 +1,51 @@
 error[E0308]: mismatched types
- --> tests/compile_fail/key_type_mismatch.rs:3:38
+ --> tests/compile_fail/key_type_mismatch.rs:4:23
   |
-3 | #[memoized(key_type = (), key_expr = a)]
-  |                       --             ^ expected `()`, found `bool`
-  |                       |
-  |                       expected due to this
+4 | #[memoized(key_expr = a, store_type = HashMap<usize, bool>)]
+  | ----------------------^-------------------------------------
+  | |                     |
+  | |                     expected `usize`, found `bool`
+  | arguments to this function are incorrect
+  |
+  = note: expected reference `&usize`
+             found reference `&bool`
+note: function defined here
+ --> tests/compile_fail/key_type_mismatch.rs:4:1
+  |
+4 | #[memoized(key_expr = a, store_type = HashMap<usize, bool>)]
+  | -^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  = note: this error originates in the attribute macro `memoized` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+ --> tests/compile_fail/key_type_mismatch.rs:4:23
+  |
+4 | #[memoized(key_expr = a, store_type = HashMap<usize, bool>)]
+  | ----------------------^-------------------------------------
+  | |                     |
+  | |                     expected `usize`, found `bool`
+  | arguments to this function are incorrect
+  |
+  = note: expected reference `&usize`
+             found reference `&bool`
+note: associated function defined here
+ --> src/lib.rs
+  |
+  |     fn get(&self, input: &I) -> Option<R>;
+  |        ^^^
+  = note: this error originates in the attribute macro `memoized` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+ --> tests/compile_fail/key_type_mismatch.rs:4:23
+  |
+4 | #[memoized(key_expr = a, store_type = HashMap<usize, bool>)]
+  | ----------------------^-------------------------------------
+  | |                     |
+  | |                     expected `usize`, found `bool`
+  | arguments to this function are incorrect
+  |
+note: associated function defined here
+ --> src/lib.rs
+  |
+  |     fn insert(&mut self, input: I, return_value: R) -> R;
+  |        ^^^^^^
+  = note: this error originates in the attribute macro `memoized` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -205,7 +205,7 @@ fn trait_functions_are_called_explicitly() {
             None
         }
     }
-    #[memoized(key_type = (), key_expr = (), store_type = Store)]
+    #[memoized(key_expr = (), store_type = Store)]
     fn f() -> () {}
     f();
 }


### PR DESCRIPTION
BREAKING CHANGE: The `key_type` parameter is removed.

Co-authored-by: Vimal Patel <mailtovimal@gmail.com>
Co-authored-by: José Manuel Peña <josemanuelp2@gmail.com>
